### PR TITLE
New server side event: onPlayerTeamChange

### DIFF
--- a/MTA10_Server/mods/deathmatch/logic/CGame.cpp
+++ b/MTA10_Server/mods/deathmatch/logic/CGame.cpp
@@ -1475,7 +1475,8 @@ void CGame::AddBuiltInEvents ( void )
     m_Events.AddEvent ( "onPlayerCommand", "command", NULL, false );
     m_Events.AddEvent ( "onPlayerModInfo", "type, ids, names", NULL, false );
     m_Events.AddEvent ( "onPlayerNetworkStatus", "type, ticks", NULL, false );
-    m_Events.AddEvent ( "onPlayerScreenShot", "resource, status, file_data, timestamp, tag", NULL, false );
+	m_Events.AddEvent ( "onPlayerScreenShot", "resource, status, file_data, timestamp, tag", NULL, false);
+	m_Events.AddEvent ( "onPlayerTeamChange", "previous, current", NULL, false);
 
     // Ped events
     m_Events.AddEvent ( "onPedWasted", "ammo, killer, weapon, bodypart", NULL, false );

--- a/MTA10_Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/MTA10_Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -9133,11 +9133,18 @@ bool CStaticFunctionDefinitions::SetPlayerTeam ( CPlayer* pPlayer, CTeam* pTeam 
 {
     assert ( pPlayer );
 
+	CTeam* oldTeam = pPlayer->GetTeam();
     // If its a different team
-    if ( pTeam != pPlayer->GetTeam () )
+    if ( pTeam != oldTeam )
     {
         // Change his team
         pPlayer->SetTeam ( pTeam, true );
+
+		// Trigger the onPlayerTeamChange event on pPlayer
+		CLuaArguments Arguments;
+		Arguments.PushElement ( oldTeam );
+		Arguments.PushElement ( pTeam );
+		pPlayer->CallEvent( "onPlayerTeamChange", Arguments );
 
         // Tell everyone his new team
         CBitStream BitStream;


### PR DESCRIPTION
This is my first pull-request and I added the onPlayerTeamChange server side event using the player as source and the handler arguments oldTeam, newTeam.

Btw, if the previous team was null, I'm still sending that value as is. So I don't know if it's an ok way to do.

Just got the idea because of a Scripting thread I replied with an homemade onPlayerTeamChange with a setTimer to check the players team because the guy needed that event.

source: The player who changed team
oldTeam: The previous player's team if any, nil otherwise
newTeam: The new player's team
